### PR TITLE
Fix patch, GNU sed compatibility, repeatability

### DIFF
--- a/0001-Remove-borders-add-padding.patch
+++ b/0001-Remove-borders-add-padding.patch
@@ -19,11 +19,11 @@ index e6ab4c6..bde883d 100644
  
  // Number of pixels margin on left and right edge.
 -#define MARGIN 5
-+#define MARGIN 25
++#define MARGIN HORIZONTAL_VAR
  
  // Number of pixels margin on the top.
 -#define VMARGIN 2
-+#define VMARGIN 25
++#define VMARGIN VERTICAL_VAR
  
  @class iTermColorMap;
  @class iTermFindOnPageHelper;

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+clean_up() {
+    if [ -e 0001-Remove-borders-add-padding.tmp.patch ]; then
+        rm 0001-Remove-borders-add-padding.tmp.patch
+    fi
+}
+
+trap clean_up SIGINT SIGTERM
+
 if [ "$#" -ne 2 ]; then
   echo "Usage install.sh <VERTICAL_PADDING> <HORIZONTAL_PADDING>"
   exit 0
@@ -12,12 +20,14 @@ fi
 VERTICAL=$1
 HORIZONTAL=$2
 
+sed -e "s/HORIZONTAL_VAR/${HORIZONTAL}/g" -e "s/VERTICAL_VAR/${VERTICAL}/g" 0001-Remove-borders-add-padding.patch > 0001-Remove-borders-add-padding.tmp.patch
+
 pushd iTerm2
 
-sed -i "" "s/HORIZONTAL_VAR/${HORIZONTAL}/g" ../0001-Remove-borders-add-padding.patch
-sed -i "" "s/VERTICAL_VAR/${VERTICAL}/g" ../0001-Remove-borders-add-padding.patch
 git checkout 2b2f92ba49370cfb072a7e0e43e9c26882bee4cc
-git apply ../0001-Remove-borders-add-padding.patch
+git apply ../0001-Remove-borders-add-padding.tmp.patch
 make
 
 popd
+
+clean_up


### PR DESCRIPTION
Replaced the in-place sed command with output to a temp file for repeatability. The in-place flag works slightly differently between BSD and GNU sed (and has the unintended side-effect of having [a change](https://github.com/jaredculp/iterm2-borderless-padding/pull/8/commits/73612c905682f55f79d81bcd680d043a7560974f#diff-1850262562014d4769248a6acc7d9f59L22) left out of your commit... 😜 )
